### PR TITLE
Should double check the password field  ...

### DIFF
--- a/application/libraries/Bitauth.php
+++ b/application/libraries/Bitauth.php
@@ -702,7 +702,7 @@ class Bitauth
 			}
 		}
 
-		if(isset($data['password']))
+		if(isset($data['password']) AND $data['password'] != '')
 		{
 			$new_password = $this->hash_password($data['password']);
 

--- a/application/libraries/Bitauth.php
+++ b/application/libraries/Bitauth.php
@@ -709,7 +709,11 @@ class Bitauth
 			$data['password'] = $new_password;
 			$data['password_last_set'] = $this->timestamp();
 		}
-
+		else
+		{
+			unset($data['password']);
+		}
+		
 		$this->db->trans_start();
 
 		if( ! empty($data))


### PR DESCRIPTION
... since the post value is a string and will always return TRUE on isset(). This fixes a bug which always updates the password on update_user even when no password is filled in.
