### PR TITLE
Fixed manual usage of transactions for Codeigniter 3.0.

### DIFF
--- a/application/libraries/Bitauth.php
+++ b/application/libraries/Bitauth.php
@@ -525,7 +525,7 @@ class Bitauth
 		$data['password'] = $this->hash_password($data['password']);
 		$data['password_last_set'] = $this->timestamp();
 
-		$this->db->trans_start();
+		$this->db->trans_begin();
 
 		$this->db->insert($this->_table['users'], $data);
 


### PR DESCRIPTION
Without this users were not being created but no error was generated.
