### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#BitAuth
+# BitAuth
 
 * [Website](http://www.dmontgomery.net/bitauth) - http://www.dmontgomery.net/bitauth
 * [Github](https://github.com/danmontgomery/codeigniter-bitauth) - https://github.com/danmontgomery/codeigniter-bitauth
 * [Issues](https://github.com/danmontgomery/codeigniter-bitauth/issues) - https://github.com/danmontgomery/codeigniter-bitauth/issues
 
-##Requirements
+## Requirements
 * PHP 5.1.6+, 5.3+ recommended
 * CodeIgniter 2.0+
 * MySQL
 * ~~php-gmp~~
 
-##Features
+## Features
 * Phpass Integration: BitAuth uses [phpass](http://www.openwall.com/phpass/) to handle password hashing
 * Password complexity rules: Along with minimum and maximum length, specify the required number of:
 	* Uppercase Characters
@@ -23,20 +23,20 @@
 * Groups and Roles: Create groups, and assign users to your groups. Your roles are set on a group, not a user, so changing roles, whether the scale is large or small, is fast and painless.
 * Text-based roles: Simply list your roles in the configuration file, then check against them in your code. BitAuth handles everything in between.
 
-##Download
+## Download
 [https://github.com/danmontgomery/codeigniter-bitauth/tarball/v0.2.1](https://github.com/danmontgomery/codeigniter-bitauth/tarball/v0.2.1)
 
-##Installation
+## Installation
 Copy the included files to their appropriate locations in the application/ folder. Import bitauth.sql into your database. **If you would like to change the names of the tables BitAuth uses, you can change them in this .sql file, and must also change them in config/bitauth.php**.
 
-##Updating
+## Updating
 If updating from v0.1.x, there is a convert() function in the Example controller. This will modify the structure of your groups table, as well as convert any roles you have stored to the new format. This function uses base_convert(), which means results may vary depending on the machine you're running this on. After upgrading, be sure to check the roles in your groups for accuracy.
 
-##Notes
+## Notes
 As of v0.2.0, php-gmp is no longer used. The structure of the bitauth_groups table has changed, as well.
 
 The default login is **admin**/**admin**.
 
 I **highly** recommend you not use the default cookie session... [Try my driver replacement](http://getsparks.org/packages/session-driver/show) for CI's session library (end of shameless self promotion).
 
-Currently, only MySQL is supported. This may change in the future. Or not. We'll see.
+Currently, only MySQL is supported. This may change in the future. Or not. We'll see


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
